### PR TITLE
USE_QUBES_REPO_TESTING = 1

### DIFF
--- a/R3.2/templates-community/whonix-14.conf
+++ b/R3.2/templates-community/whonix-14.conf
@@ -27,6 +27,10 @@ BRANCH_template_whonix = master
 
 USE_QUBES_REPO_VERSION = 3.2
 
+# required because of https://github.com/QubesOS/qubes-issues/issues/4095
+# required until https://github.com/QubesOS/updates-status/issues/593 hits Qubes stable repository
+USE_QUBES_REPO_TESTING = 1
+
 # override default version set in tb-updater package
 #WHONIX_TBB_VERSION = 7.0.6
 


### PR DESCRIPTION
required because of QubesOS/qubes-issues#4095

required until QubesOS/updates-status#593 hits Qubes stable repository